### PR TITLE
cli: Fix FTBFS on kfreebsd

### DIFF
--- a/examples/libstoken-test.c
+++ b/examples/libstoken-test.c
@@ -96,8 +96,7 @@ static void stdin_echo(int enable_echo)
 		tcflush(fd, TCIFLUSH);
 		tio = oldtio;
 
-		tio.c_iflag &= ~(IUCLC|IXON|IXOFF|IXANY);
-		tio.c_lflag &= ~(ECHO|ECHOE|ECHOK|ECHONL|TOSTOP);
+		tio.c_lflag &= ~(ECHO|ECHOE|ECHOK|ECHONL);
 		tcsetattr(fd, TCSANOW, &tio);
 
 		/* restore a sane terminal state if interrupted */

--- a/src/cli.c
+++ b/src/cli.c
@@ -91,8 +91,7 @@ static void stdin_echo(int enable_echo)
 	if (!enable_echo) {
 		/* ripped from busybox bb_ask() */
 		tcflush(fd, TCIFLUSH);
-		tio.c_iflag &= ~(IUCLC|IXON|IXOFF|IXANY);
-		tio.c_lflag &= ~(ECHO|ECHOE|ECHOK|ECHONL|TOSTOP);
+		tio.c_lflag &= ~(ECHO|ECHOE|ECHOK|ECHONL);
 		tcsetattr(fd, TCSANOW, &tio);
 	} else
 		tcsetattr(fd, TCSANOW, &oldtio);


### PR DESCRIPTION
Update terminal handling borrowed from busybox. Do not modify any input
mode bits. Do not clear the TOSTOP mode flag.

Do the same for the example program.

Signed-off-by: Mike Miller mtmiller@ieee.org
