### PR TITLE
Fix broken build on systems w/o system versioning support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -9,7 +9,9 @@ lib_LTLIBRARIES		= libstoken.la
 libstoken_la_SOURCES	= src/library.c src/securid.c src/sdtid.c
 libstoken_la_CFLAGS	= $(AM_CFLAGS)
 libstoken_la_LDFLAGS	= -version-number @APIMAJOR@:@APIMINOR@
+if HAVE_LD_VERSION_SCRIPT
 libstoken_la_LDFLAGS	+= -Wl,--version-script,@srcdir@/libstoken.map
+endif
 libstoken_la_LIBADD	= $(TOMCRYPT_LIBS) $(LIBXML2_LIBS)
 libstoken_la_DEPENDENCIES = libstoken.map
 include_HEADERS		= src/stoken.h

--- a/configure.ac
+++ b/configure.ac
@@ -189,6 +189,19 @@ AC_ARG_ENABLE([jni-standalone],
 	[jni_standalone=no])
 AM_CONDITIONAL(JNI_STANDALONE, [test $jni_standalone = yes])
 
+# Check for symbol versioning support
+
+AC_MSG_CHECKING([if libraries can be versioned])
+GLD=`$LD --help < /dev/null 2>/dev/null | grep version-script`
+if test "$GLD"; then
+    have_ld_version_script=yes
+    AC_MSG_RESULT(yes)
+else
+    have_ld_version_script=no
+    AC_MSG_RESULT(no)
+fi
+AM_CONDITIONAL(HAVE_LD_VERSION_SCRIPT, test "$have_ld_version_script" = "yes")
+
 # library version
 
 libhdr=${srcdir}/src/stoken.h


### PR DESCRIPTION
This pull request should fix build on systems without versioning script support (e.g. OS X). This fixing issue https://github.com/cernekee/stoken/issues/9
