### PR TITLE
autoconf: check for mkstemps

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -72,6 +72,9 @@ AC_SUBST(WFLAGS, [$WFLAGS])
 # mlockall() is missing on Bionic (Android)
 AC_CHECK_FUNCS(mlockall)
 
+# mkstemps is missing on uClibc
+AC_CHECK_FUNCS(mkstemps)
+
 # TODO: see if compatibility functions are needed to build on Darwin
 AC_CHECK_FUNCS(strcasestr asprintf)
 


### PR DESCRIPTION
mkstemps is missing on uClibc, and until recently was also missing with
musl-libc. Add an explicit check for this function.

Signed-off-by: Florian Fainelli f.fainelli@gmail.com
