### PR TITLE
edit in fopen_rcfile : now also trying to use envvar USERPROFILE as home

### DIFF
--- a/src/library.c
+++ b/src/library.c
@@ -199,6 +199,9 @@ static int fopen_rcfile(const char *override, const char *mode,
 	if (!override) {
 		homedir = getenv("HOME");
 		if (!homedir) {
+			homedir = getenv("USERPROFILE");
+		}
+		if (!homedir) {
 			warn_fn("rcfile: HOME is not set so I can't read '%s'\n",
 				RC_NAME);
 			return ERR_GENERAL;


### PR DESCRIPTION
edit in fopen_rcfile : now also trying to use envvar USERPROFILE as home, because Windows by default does not have HOME envvar. USERPROFILE is the same as HOME on linux. Typically on win7 it is "C:\Users\yourusername"
