### PR TITLE
Remove bash specifics

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 AUTOMAKE_OPTIONS	= foreign subdir-objects
 ACLOCAL_AMFLAGS		= -I m4
-SHELL			= /bin/bash
+SHELL			= /bin/sh
 
 AM_CPPFLAGS		= -DDATA_DIR=\"$(datadir)\"
 AM_CFLAGS		= $(CRYPTO_CFLAGS) $(LIBXML2_CFLAGS) $(WFLAGS)

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ with Apple's libtool program:
     export LIBTOOL=glibtool
     git clone git://github.com/cernekee/stoken
     cd stoken
-    bash autogen.sh
+    ./autogen.sh
     ./configure
     make
     make check
@@ -122,7 +122,7 @@ dependencies:
 
     git clone git://github.com/cernekee/stoken
     cd stoken
-    bash autogen.sh
+    ./autogen.sh
     mingw32-configure
     make winpkg
 

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -ex
 

--- a/release.sh
+++ b/release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 gpgkey="BC0B0D65"
 


### PR DESCRIPTION
There aren't really bash features being used in these scripts so just
use /bin/sh. On most Linux systems this is symlink'd to bash anyway.

The explicit usage of bash in the Makefile causes build failures on
systems where bash is not installed e.g. BSD's unless overridden.

Also remove shell specific invocation of auotgen.sh in the README.