### PR TITLE
use the libtool in the build directory

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -94,6 +94,7 @@ PIPE_LOG_COMPILER	= $(srcdir)/tests/pipe-wrapper.sh
 dist_check_SCRIPTS	= $(TESTS) $(PIPE_LOG_COMPILER)
 
 TESTS_ENVIRONMENT 	= STOKEN=./stoken \
+			LIBTOOL="${LIBTOOL}" \
 			TESTDIR="$(srcdir)/tests"
 
 if ENABLE_VALGRIND

--- a/tests/pipe-wrapper.sh
+++ b/tests/pipe-wrapper.sh
@@ -22,8 +22,9 @@ base="${base%.pipe}"
 
 TESTDIR="${TESTDIR:-.}"
 STOKEN="${STOKEN:-../stoken}"
+LIBTOOL="${LIBTOOL:-../libtool}"
 if ! test -z "${VALGRIND}"; then
-	STOKEN="${LIBTOOL:-libtool} --mode=execute ${VALGRIND} ${STOKEN}"
+	STOKEN="${LIBTOOL} --mode=execute ${VALGRIND} ${STOKEN}"
 fi
 
 tok0="--token=258491750817210752367175001073261277346642631755724762324173166222072472716737543"


### PR DESCRIPTION
When calling libtool directly, make sure it is the generated libtool
script in the project top build directory.  On current Debian systems,
it is possible to have libtool installed but without a general-purpose
libtool executable in $PATH.

Not sure how this will interact with the macOS glibtool workaround.