### PR TITLE
be compatible with libtomcrypt 1.18

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -185,6 +185,14 @@ if test "$with_tomcrypt" != no -a "$with_nettle" != yes; then
 		 EXTRA_PC_LIBS="$EXTRA_PC_LIBS $TOMCRYPT_PC_LIBS"],
 		[AC_MSG_RESULT([no])])
 
+	AC_MSG_CHECKING([whether libtomcrypt uses newer LTC_PKCS_1_V1_5 naming convention])
+	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include <tomcrypt.h>],
+		[int padding = LTC_PKCS_1_V1_5;])],
+		[AC_MSG_RESULT([yes])],
+		[AC_MSG_RESULT([no])
+		 AC_DEFINE([LIBTOMCRYPT_OLD_PKCS_NAMES], [1],
+			   [libtomcrypt uses the pre-1.18 PKCS #1 constant naming convention])])
+
 	LIBS="$saved_LIBS"
 	CFLAGS="$saved_CFLAGS"
 fi

--- a/src/stc-tomcrypt.c
+++ b/src/stc-tomcrypt.c
@@ -37,6 +37,11 @@
 #define AES_KEY_SIZE		16
 #define AES256_KEY_SIZE		32
 
+/* Backwards compatibility support for pre-1.18 versions of libtomcrypt */
+#ifdef LIBTOMCRYPT_OLD_PKCS_NAMES
+#define LTC_PKCS_1_V1_5 LTC_LTC_PKCS_1_V1_5
+#endif
+
 int stc_standalone_init(void)
 {
 	/* libtomcrypt init for sdtid BatchSignature generation */
@@ -190,7 +195,7 @@ int stc_rsa_sha1_sign_digest(const uint8_t *privkey_der, size_t privkey_len,
 	if (rsa_import(privkey_der, privkey_len, &key) != CRYPT_OK)
 		return ERR_GENERAL;
 	if (rsa_sign_hash_ex(digest, (160 / 8), out, outlen,
-			     LTC_LTC_PKCS_1_V1_5, NULL, 0,
+			     LTC_PKCS_1_V1_5, NULL, 0,
 			     hash_idx, 0, &key) != CRYPT_OK)
 		rc = ERR_GENERAL;
 


### PR DESCRIPTION
In libtomcrypt 1.18 the `LTC_LTC_PKCS_1_*` constants were renamed to `LTC_PKCS_1_*`.  Add an autoconf test for this change and define an alias to the old name when building against the older API.

Locally tested, successfully builds with both libtomcrypt 1.17 and 1.18.

This should fix [Debian #878883](https://bugs.debian.org/878883).