### PR TITLE
fix build in new travis trusty environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,10 @@ script:
   - ./autogen.sh
   - misc/build-one.sh nettle
   - if [ "$TRAVIS_OS_NAME" != "osx" ]; then
+        case "$CC" in
+            clang*) export CPPFLAGS=-DLTC_NO_ROLC ;;
+            *) ;;
+        esac;
         misc/build-one.sh tomcrypt &&
         ./release.sh &&
         misc/build-debian.sh &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ notifications:
 before_install:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then
         brew update;
-        brew install autoconf automake libtool nettle valgrind;
+        brew install nettle valgrind;
     else
         sudo apt-get update -qq &&
         sudo apt-get install -qq autoconf automake libtool debhelper libgtk-3-dev libtomcrypt-dev libxml2-dev dh-autoreconf devscripts fakeroot git-core valgrind nettle-dev;

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ notifications:
 
 before_install:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then
+        brew update;
         brew install autoconf automake libtool nettle valgrind;
     else
         sudo apt-get update -qq &&


### PR DESCRIPTION
The default Travis environment has been upgraded to Ubuntu trusty. It also includes clang 3.9 instead of the default clang that comes from the distro. This breaks building with tomcrypt 1.17, so add a `-DLTC_NO_ROLC` compiler flag to work around the problems in the headers.

This is only done for the Travis build script, I think it's fair to not bother adding an autoconf check to try to address this automatically. If someone is building with a new clang and an old tomcrypt, they should be able to pass the option if needed.