### PR TITLE
cleanup: remove bashism

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,5 @@
 AUTOMAKE_OPTIONS	= foreign subdir-objects
 ACLOCAL_AMFLAGS		= -I m4
-SHELL			= /bin/bash
 
 AM_CPPFLAGS		= -DDATA_DIR=\"$(datadir)\"
 AM_CFLAGS		= $(CRYPTO_CFLAGS) $(LIBXML2_CFLAGS) $(WFLAGS)

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ with Apple's libtool program:
     export LIBTOOL=glibtool
     git clone git://github.com/cernekee/stoken
     cd stoken
-    bash autogen.sh
+    ./autogen.sh
     ./configure
     make
     make check
@@ -122,7 +122,7 @@ dependencies:
 
     git clone git://github.com/cernekee/stoken
     cd stoken
-    bash autogen.sh
+    ./autogen.sh
     mingw32-configure
     make winpkg
 

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -ex
 

--- a/misc/build-debian.sh
+++ b/misc/build-debian.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 gpgkey="BC0B0D65"
 ppaname="cernekee/ppa"
@@ -6,13 +6,13 @@ ppaname="cernekee/ppa"
 builddir=tmp.debian
 pkg=stoken
 
-function build_one
-{
+build_one() {
 	arg="$1"
 
 	rm -rf $builddir
+	mydir=$(pwd)
 	mkdir $builddir
-	pushd $builddir
+	cd $builddir
 
 	cp ../$tarball "${pkg}_${ver}.orig.tar.gz"
 	mkdir "$pkg-$ver"
@@ -26,7 +26,7 @@ function build_one
 	fi
 	cd ..
 	lintian -IE --pedantic *.changes | tee -a ../lintian.txt || true
-	popd
+	cd $mydir
 }
 
 #
@@ -61,7 +61,7 @@ fi
 ver=${tarball#*-}
 ver=${ver%%.tar.gz}
 
-if gpg --list-secret-keys $gpgkey >& /dev/null; then
+if gpg --list-secret-keys $gpgkey > /dev/null 2>&1; then
 	nosign=0
 else
 	nosign=1

--- a/misc/build-one.sh
+++ b/misc/build-one.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -ex
 
@@ -27,7 +27,7 @@ fi
 
 rm -rf build.$lib
 mkdir build.$lib
-pushd build.$lib
+cd build.$lib
 ../configure --enable-valgrind $args
 make
 
@@ -38,6 +38,6 @@ for x in Pacific/Honolulu America/New_York Europe/Athens \
 done
 
 make dist
-popd
+cd ..
 
 exit 0

--- a/tests/pipe-wrapper.sh
+++ b/tests/pipe-wrapper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Each .pipe file contains a "pipeline" of commands.  Compare the output
 # of the FINAL command to <foo>.ref
@@ -14,7 +14,7 @@
 set -ex
 
 base="$1"
-if [[ "$base" != *.pipe ]]; then
+if [ "${base%.pipe}" = "${base}" ]; then
 	echo "Invalid test file: $base"
 	exit 1
 fi


### PR DESCRIPTION
Hi,

This is a patch to remove bashism in favor of POSIX shell. The simplicity of the scripts is within the scope of POSIX, there is no reason to force bash for the build/test of the component.

All but the debian scripts tested and seems to work, please test it as well.

Thanks!