### PR TITLE
Fix Travis for macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ notifications:
 before_install:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then
         brew update;
-        brew install nettle valgrind;
+        brew install valgrind;
+        brew upgrade nettle;
     else
         sudo apt-get update -qq &&
         sudo apt-get install -qq autoconf automake libtool debhelper libgtk-3-dev libtomcrypt-dev libxml2-dev dh-autoreconf devscripts fakeroot git-core valgrind nettle-dev;


### PR DESCRIPTION
Travis already has `brew`'s `nettle` package. Installing it again [is failing.](https://travis-ci.org/cernekee/stoken/jobs/348940908)

This commit may be rebased. Do not merge until this message is removed.