### PR TITLE
Add totally untested OMAC1-AES, CT-KIP-PRF-{AES,SHA256}

### DIFF
--- a/src/stoken-internal.h
+++ b/src/stoken-internal.h
@@ -21,6 +21,7 @@
 #ifndef __STOKEN_INTERNAL_H__
 #define __STOKEN_INTERNAL_H__
 
+#include <stdarg.h>
 #include <stdint.h>
 #include "stoken.h"
 
@@ -101,6 +102,8 @@ void stc_aes256_cbc_decrypt(const uint8_t *key, const uint8_t *in, int in_len,
 			       const uint8_t *iv, uint8_t *out);
 void stc_aes256_cbc_encrypt(const uint8_t *key, const uint8_t *in, int in_len,
 			       const uint8_t *iv, uint8_t *out);
+void stc_omac1_aes(const void *key, size_t klen, void *result, size_t reslen,
+		   ...);
 void stc_sha1_hash(uint8_t *out, ...);
 void stc_sha256_hash(uint8_t *out, ...);
 int stc_b64_encode(const uint8_t *in,  unsigned long len,


### PR DESCRIPTION
Add totally untested implementations of the OMAC1-AES ("CMAC") and
CT-KIP-PRF-* family of pseudo-random functions per relevant RFCs.  It
compiles but that's about all I've tested.

Broken:
* Only supports tomcrypt
* Untested!!!
* Mallocs in PRF-SHA256 variant to work around missing iterative
  sha256-hmac.  Could add iterative hmac instead and skip malloc.

Re: #27

(Not necessarily useful to pull as-is, but may be useful as a starting place.)