### PR TITLE
Some minor enhancements / update of MingW Windows build

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -110,7 +110,7 @@ winpkg: $(bin_PROGRAMS)
 	cp .libs/stoken.exe winpkg/
 if ENABLE_GUI
 	cp .libs/stoken-gui.exe winpkg/
-	cp `./win32deps.pl .libs/stoken-gui.exe` winpkg/
+	cp `CC=$(CC) ./win32deps.pl .libs/stoken-gui.exe` winpkg/
 	cp gui/*.{ui,png} winpkg/
 else
 	cp .libs/stoken.exe winpkg/

--- a/README.md
+++ b/README.md
@@ -113,18 +113,17 @@ or maintained regularly.
 
 #### Initial setup
 
-On a Fedora 20 PC (other versions may work as well), install the build
+On a Fedora 28 PC (other versions may work as well), install the build
 dependencies:
 
-    yum groupinstall "Development Tools"
-    yum install git autoconf automake libtool mingw32-gnutls mingw32-libxml2 mingw32-gtk3
+    dnf install git autoconf automake libtool mingw64-gnutls mingw64-libxml2 mingw64-gtk3 mingw64-binutils
 
 #### Compiling
 
     git clone git://github.com/cernekee/stoken
     cd stoken
     bash autogen.sh
-    mingw32-configure
+    mingw64-configure GTK_LIBS="$(x86_64-w64-mingw32-pkg-config --libs "gtk+-3.0") -Wl,--subsystem,windows"
     make winpkg
 
 If all goes well, you should be able to copy <code>winpkg.zip</code> to

--- a/win32deps.pl
+++ b/win32deps.pl
@@ -35,8 +35,8 @@ my %blacklist = (
 	"setupapi.dll" => 1,
 );
 
-my $CC = "i686-w64-mingw32-gcc";
-my $OBJDUMP = "mingw-objdump";
+my $CC = $ENV{'CC'};
+my $OBJDUMP = $ENV{'OBJDUMP'} // $CC =~ s/-gcc$/-objdump/r;
 
 sub run($)
 {


### PR DESCRIPTION
Make 'winpkg' target 32- or 64-bit agnostic and document 64-bit build on more recent Fedora.

Document how to build stoken-gui.exe as a Windows mode application without a console.

With this, stoken-gui.exe works quite well for me on Windows 10.  It doesn't seem to remember the saved pin, but can read the saved token.  I'm not sure why and can't really debug.  But one can create a shortcut to stoken-gui.exe with `--pin ABCDEFGH` as a workaround.