### PR TITLE
Feature / Print both current and next tokens

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -478,7 +478,7 @@ int main(int argc, char **argv)
 			securid_compute_tokencode(t, adjusted_time(t), buf);
 			opt_next = 1;
 			securid_compute_tokencode(t, adjusted_time(t), buf_next);
-			printf("\nCurrent: %s\nNext:    %s\n", buf, buf_next);
+			printf("Current tokencode: %s\n   Next tokencode: %s\n", buf, buf_next);
 		} else {
 			securid_compute_tokencode(t, adjusted_time(t), buf);
 			puts(buf);

--- a/src/cli.c
+++ b/src/cli.c
@@ -181,6 +181,8 @@ static time_t adjusted_time(struct securid_token *t)
 	time_t now = time(NULL);
 	long new_time;
 
+	if (opt_both && opt_use_time)
+		die("error: --use-time and --both are mutually exclusive\n");
 	if (opt_next && opt_use_time)
 		die("error: --use-time and --next are mutually exclusive\n");
 	if (opt_next)

--- a/src/cli.c
+++ b/src/cli.c
@@ -443,7 +443,7 @@ int main(int argc, char **argv)
 {
 	char *cmd = parse_cmdline(argc, argv, NOT_GUI);
 	int rc;
-	char buf[BUFLEN];
+	char buf[BUFLEN], buf_next[BUFLEN];
 	struct securid_token *t;
 
 	rc = common_init(cmd);
@@ -473,8 +473,16 @@ int main(int argc, char **argv)
 		if (days_left < 0 && !opt_force)
 			die("error: token has expired; use --force to override\n");
 
-		securid_compute_tokencode(t, adjusted_time(t), buf);
-		puts(buf);
+		if (opt_both) {
+			opt_next = 0;
+			securid_compute_tokencode(t, adjusted_time(t), buf);
+			opt_next = 1;
+			securid_compute_tokencode(t, adjusted_time(t), buf_next);
+			printf("\nCurrent: %s\nNext:    %s\n", buf, buf_next);
+		} else {
+			securid_compute_tokencode(t, adjusted_time(t), buf);
+			puts(buf);
+		}
 
 		if (days_left < 14 && !opt_force)
 			warn("warning: token expires in %d day%s\n", days_left,

--- a/src/common.c
+++ b/src/common.c
@@ -223,8 +223,8 @@ static void usage_cli(void)
 	puts("Options for tokencode");
 	puts("");
 	puts("  --stdin            Read PIN from STDIN");
-	puts("  --next             Print next token");
-	puts("  --both             Print both current and next token");
+	puts("  --next             Print next tokencode");
+	puts("  --both             Print both current and next tokencode");
 	puts("  --use-time=<time>  Use <time> to generate token");
 	puts("");
 	puts("Other commands:");

--- a/src/common.c
+++ b/src/common.c
@@ -220,6 +220,13 @@ static void usage_cli(void)
 	puts("  stoken setpass");
 	puts("  stoken setpin");
 	puts("");
+	puts("Options for tokencode");
+	puts("");
+	puts("  --stdin            Read PIN from STDIN");
+	puts("  --next             Print next token");
+	puts("  --both             Print both current and next token");
+	puts("  --use-time=<time>  Use <time> to generate token");
+	puts("");
 	puts("Other commands:");
 	puts("");
 	puts("  stoken show [ --seed ]");

--- a/src/common.c
+++ b/src/common.c
@@ -41,7 +41,7 @@
 /* globals - shared with cli.c or gui.c */
 
 int opt_random, opt_keep_password, opt_blocks, opt_iphone, opt_android,
-	opt_v3, opt_show_qr, opt_seed, opt_sdtid, opt_small, opt_next;
+	opt_v3, opt_show_qr, opt_seed, opt_sdtid, opt_small, opt_next, opt_both;
 int opt_debug, opt_version, opt_help, opt_batch, opt_force, opt_stdin;
 char *opt_rcfile, *opt_file, *opt_token, *opt_devid, *opt_password,
      *opt_pin, *opt_use_time, *opt_new_password, *opt_new_devid,
@@ -168,6 +168,7 @@ static const struct option long_opts[] = {
 
 	/* used for tokencode generation */
 	{ "next",           0, &opt_next,               1                 },
+	{ "both",           0, &opt_both,               1                 },
 
 	/* these are mostly for exporting/issuing tokens */
 	{ "new-password",   1, NULL,                    OPT_NEW_PASSWORD  },

--- a/src/common.h
+++ b/src/common.h
@@ -64,7 +64,7 @@ char *format_token(const char *raw_token_str);
 
 /* binary flags, long options */
 extern int opt_random, opt_keep_password, opt_blocks, opt_iphone, opt_android,
-	opt_v3, opt_show_qr, opt_seed, opt_sdtid, opt_small, opt_next;
+	opt_v3, opt_show_qr, opt_seed, opt_sdtid, opt_small, opt_next, opt_both;
 
 /* binary flags, short/long options */
 extern int opt_debug, opt_version, opt_help, opt_batch, opt_force, opt_stdin;


### PR DESCRIPTION
- Add option `--both` to print both current and next tokens in a single command.
- Update help output.

```
stoken --both
Enter PIN:
Current tokencode: 04832807
   Next tokencode: 11857309
```

Note: I will need help to update tests, if required.
