### PR TITLE
stc-nettle: initialize base64 decode buffer length

### DIFF
--- a/src/stc-nettle.c
+++ b/src/stc-nettle.c
@@ -137,7 +137,7 @@ int stc_b64_decode(const uint8_t *in,  unsigned long len,
 	struct base64_decode_ctx ctx;
 	char tmp[BASE64_DECODE_LENGTH(len)];
 	int ret;
-	size_t dst_length;
+	size_t dst_length = sizeof(tmp);
 
 	base64_decode_init(&ctx);
 	ret = base64_decode_update(&ctx, &dst_length, tmp, len, in);


### PR DESCRIPTION
nettle's base64_decode_update() treats *dst_length as the size of the output buffer on input and updates it with the number of bytes written on success.

stoken passed an uninitialized local variable for that argument, which makes SDTID import depend on stack contents. In practice this can make valid SDTID test fixtures fail to decode their Seed field with 'missing required xml node Seed'.

Initialize dst_length to the size of the temporary decode buffer before calling into nettle.